### PR TITLE
Add UIKit import to HistoryView

### DIFF
--- a/ProteinFlip/HistoryView.swift
+++ b/ProteinFlip/HistoryView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct HistoryView: View {
     @EnvironmentObject var store: ProteinStore


### PR DESCRIPTION
## Summary
- import UIKit in HistoryView to enable UIKit APIs

## Testing
- `swiftc -typecheck ProteinFlip/HistoryView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68ae2e60bb748332a3a8f725155d5d0b