### PR TITLE
Track last protein addition for undo

### DIFF
--- a/ProteinFlip/HomeView.swift
+++ b/ProteinFlip/HomeView.swift
@@ -7,6 +7,7 @@ struct HomeView: View {
     @State private var displayValue: Int = 0
     @State private var showHistory = false
     @State private var showGoals = false
+    @State private var lastAddition: Int?
 
     var body: some View {
         NavigationStack {
@@ -110,14 +111,17 @@ struct HomeView: View {
     }
 
     private func addQuick(_ v: Int) {
+        lastAddition = v
         addAmount = Double(v)
         addTapped()
     }
 
     private func undoLast() {
-        let newVal = max(0, store.todayGrams - Int(addAmount))
+        guard let last = lastAddition else { return }
+        let newVal = max(0, store.todayGrams - last)
         store.set(for: Date(), grams: newVal)
         animateTo(newVal)
+        lastAddition = nil
         Haptics.warning()
     }
 
@@ -128,6 +132,7 @@ struct HomeView: View {
         let start = store.todayGrams
         let target = start + inc
         store.add(grams: inc)
+        lastAddition = inc
         animateTo(target)
         if target >= store.goalGrams, start < store.goalGrams {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { Haptics.success() }


### PR DESCRIPTION
## Summary
- Remember last protein increment with new `lastAddition` state
- Set `lastAddition` on quick adds and standard additions
- Undo subtracts the recorded amount and clears `lastAddition`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2fe088648332a961243b9ef9ebe2