### PR TITLE
Fix environment object references and toolbar placement

### DIFF
--- a/ProteinFlip/GoalsView.swift
+++ b/ProteinFlip/GoalsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct GoalsView: View {
-    @EnvironmentObject var store: ProteinStore
+    @EnvironmentObject var proteinStore: ProteinStore
     @Environment(\.dismiss) private var dismiss
 
     @State private var goal: Double = 130
@@ -21,7 +21,7 @@ struct GoalsView: View {
                         Text("\(Int(goal)) g")
                     }
                     Button("Save") {
-                        store.goalGrams = Int(goal)
+                        proteinStore.goalGrams = Int(goal)
                         dismiss()
                     }
                 }
@@ -43,7 +43,7 @@ struct GoalsView: View {
                         let kg = unit == .kg ? w : w * 0.45359237
                         let g = Int((kg * 1.7).rounded())
                         goal = Double(g)
-                        store.goalGrams = g
+                        proteinStore.goalGrams = g
                         Haptics.success()
                     }
                 }
@@ -60,7 +60,7 @@ struct GoalsView: View {
                     Button("Close") { dismiss() }
                 }
             }
-            .onAppear { goal = Double(store.goalGrams) }
+            .onAppear { goal = Double(proteinStore.goalGrams) }
         }
     }
 }

--- a/ProteinFlip/HistoryView.swift
+++ b/ProteinFlip/HistoryView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UIKit
 
 struct HistoryView: View {
-    @EnvironmentObject var store: ProteinStore
+    @EnvironmentObject var proteinStore: ProteinStore
     @Environment(\.dismiss) private var dismiss
     @State private var month: Date = Date()
 
@@ -17,7 +17,7 @@ struct HistoryView: View {
             .padding()
             .navigationTitle("History")
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Close") { dismiss() }
                 }
             }
@@ -54,7 +54,7 @@ struct HistoryView: View {
         let cal = Calendar.current
         let startOfMonth = cal.date(from: cal.dateComponents([.year, .month], from: month))!
         let firstWeekday = (cal.component(.weekday, from: startOfMonth) + 5) % 7 // Monday index 0
-        let days = store.monthData(for: month)
+        let days = proteinStore.monthData(for: month)
         let blanks = Array(repeating: "", count: firstWeekday)
 
         let cells: [AnyView] =
@@ -87,8 +87,8 @@ struct HistoryView: View {
     }
 
     private func goalStatus(grams: Int) -> (colour: Color, text: String) {
-        if grams >= store.goalGrams { return (.green, "Goal hit") }
-        if grams >= Int(Double(store.goalGrams) * 0.6) { return (.orange, "Nearly there") }
+        if grams >= proteinStore.goalGrams { return (.green, "Goal hit") }
+        if grams >= Int(Double(proteinStore.goalGrams) * 0.6) { return (.orange, "Nearly there") }
         return (.red, "Low")
     }
 
@@ -103,7 +103,7 @@ struct HistoryView: View {
         alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
             if let t = alert.textFields?.first?.text, let g = Int(t) {
                 newVal = max(0, g)
-                store.set(for: date, grams: newVal)
+                proteinStore.set(for: date, grams: newVal)
             }
         }))
         UIApplication.shared.topMost?.present(alert, animated: true)


### PR DESCRIPTION
## Summary
- Rename `store` to `proteinStore` in GoalsView and HistoryView for clarity and avoid scope errors
- Use `navigationBarTrailing` to replace unsupported `topBarTrailing` toolbar placement

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae30d59eec83329408e4c0181ca5d3