### PR TITLE
Ensure environment object is passed to sheet views

### DIFF
--- a/ProteinFlip/HomeView.swift
+++ b/ProteinFlip/HomeView.swift
@@ -67,8 +67,8 @@ struct HomeView: View {
                     }
                 }
             }
-            .sheet(isPresented: $showHistory) { HistoryView() }
-            .sheet(isPresented: $showGoals) { GoalsView() }
+            .sheet(isPresented: $showHistory) { HistoryView().environmentObject(store) }
+            .sheet(isPresented: $showGoals) { GoalsView().environmentObject(store) }
             .onAppear {
                 displayValue = store.todayGrams
                 Haptics.prepare()

--- a/ProteinFlip/ProteinFlipApp.swift
+++ b/ProteinFlip/ProteinFlipApp.swift
@@ -7,9 +7,9 @@ struct ProteinFlipApp: App {
     var body: some Scene {
         WindowGroup {
             HomeView()
-                .environmentObject(store)
                 .onAppear { store.handleRolloverIfNeeded() }
         }
+        .environmentObject(store)
     }
 }
 


### PR DESCRIPTION
## Summary
- Scope environment object at window level for ProteinFlipApp
- Pass ProteinStore into HistoryView and GoalsView sheets

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af69aeef488332a0312a640a896dc1