### PR TITLE
Add CFBundleExecutable to app Info.plist

### DIFF
--- a/ProteinFlip/Info.plist
+++ b/ProteinFlip/Info.plist
@@ -6,6 +6,8 @@
     <string>$(PRODUCT_NAME)</string>
     <key>CFBundleIdentifier</key>
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary
- ensure Info.plist includes `CFBundleExecutable` so built app has a valid executable entry

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af69adbe38833282de26454c42e92e