### PR TITLE
Disable multiple scenes

### DIFF
--- a/ProteinFlip/Info.plist
+++ b/ProteinFlip/Info.plist
@@ -14,5 +14,10 @@
     <string>1.0</string>
     <key>UILaunchStoryboardName</key>
     <string>LaunchScreen</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Disable multi-scene support by adding `UIApplicationSceneManifest` with `UIApplicationSupportsMultipleScenes` set to false in Info.plist

## Testing
- `xcodebuild -scheme ProteinFlip clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6b9610d083329379f8ed869e6641