### PR TITLE
Clip digit halves in SplitFlapDigit

### DIFF
--- a/ProteinFlip/FlipDigit.swift
+++ b/ProteinFlip/FlipDigit.swift
@@ -20,6 +20,7 @@ struct SplitFlapDigit: View {
                         .foregroundStyle(.white)
                         .baselineOffset(2)
                         .frame(height: half)
+                        .clipped()
                 }
                 .frame(height: half)
                 .overlay(Rectangle().fill(Color.black.opacity(0.4)).frame(height: 1), alignment: .bottom)
@@ -31,6 +32,7 @@ struct SplitFlapDigit: View {
                         .foregroundStyle(.white.opacity(0.95))
                         .baselineOffset(-2)
                         .frame(height: half)
+                        .clipped()
                 }
                 .frame(height: half)
             }


### PR DESCRIPTION
## Summary
- Ensure both halves of SplitFlapDigit display only their portion by clipping the top and bottom text layers.

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af707951ec83328a26b50cf6b59466