### PR TITLE
Simplify progress ring in HomeView

### DIFF
--- a/ProteinFlip/HomeView.swift
+++ b/ProteinFlip/HomeView.swift
@@ -78,31 +78,33 @@ struct HomeView: View {
 
     @ViewBuilder
     private var progressRing: some View {
-        if store.goalGrams > 0 {
+        if store.goalGrams > 0 && store.todayGrams < store.goalGrams {
             let p = min(Double(store.todayGrams) / Double(store.goalGrams), 1.0)
             let colour: Color = p >= 1 ? .green : (p >= 0.6 ? .orange : .red)
             ZStack {
-                Circle().stroke(Color.secondary.opacity(0.2), lineWidth: 12)
+                Circle().stroke(Color.secondary.opacity(0.2), lineWidth: 8)
                 Circle()
                     .trim(from: 0, to: p)
-                    .stroke(colour, style: StrokeStyle(lineWidth: 12, lineCap: .round))
+                    .stroke(colour, style: StrokeStyle(lineWidth: 8, lineCap: .round))
                     .rotationEffect(.degrees(-90))
-                VStack {
-                    Text("\(store.todayGrams) / \(store.goalGrams) g").font(.headline)
-                    Text(p >= 1 ? "Goal hit" : "Keep going")
-                        .font(.footnote).foregroundStyle(.secondary)
-                }
+                Text("\(Int(p * 100))%")
+                    .font(.subheadline.bold())
+                    .foregroundStyle(colour)
             }
-            .frame(width: 180, height: 180)
-            .padding(.bottom, 6)
+            .frame(width: 120, height: 120)
+            .padding(.bottom, 4)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(Text("Progress \(Int(p*100)) percent"))
-        } else {
-            Text("Set a goal to see your progress")
+        } else if store.goalGrams > 0 {
+            Text("Goal hit!")
                 .font(.headline)
+                .foregroundStyle(.green)
+                .padding(.bottom, 4)
+        } else {
+            Text("Set a goal to see progress")
+                .font(.subheadline)
                 .foregroundStyle(.secondary)
-                .frame(width: 180, height: 180)
-                .padding(.bottom, 6)
+                .padding(.bottom, 4)
         }
     }
 


### PR DESCRIPTION
## Summary
- Reduce progress ring size and stroke, showing only percent to lessen visual prominence
- Hide ring once goal is reached, displaying a small success message instead

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project ProteinFlip.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7084f5cc8332a69e68befd5a55bd