### PR TITLE
Align counter and progress ring

### DIFF
--- a/ProteinFlip/HomeView.swift
+++ b/ProteinFlip/HomeView.swift
@@ -14,7 +14,9 @@ struct HomeView: View {
             VStack(spacing: 28) {
                 Spacer(minLength: 12)
 
-                SplitFlapCounter(value: displayValue, fontSize: 72)
+                SplitFlapCounter(value: displayValue, fontSize: 80)
+                    .frame(width: 140)
+                    .frame(maxWidth: .infinity, alignment: .center)
 
                 progressRing
 
@@ -91,7 +93,8 @@ struct HomeView: View {
                     .font(.subheadline.bold())
                     .foregroundStyle(colour)
             }
-            .frame(width: 120, height: 120)
+            .frame(width: 140, height: 140)
+            .frame(maxWidth: .infinity, alignment: .center)
             .padding(.bottom, 4)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(Text("Progress \(Int(p*100)) percent"))
@@ -99,11 +102,13 @@ struct HomeView: View {
             Text("Goal hit!")
                 .font(.headline)
                 .foregroundStyle(.green)
+                .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.bottom, 4)
         } else {
             Text("Set a goal to see progress")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.bottom, 4)
         }
     }


### PR DESCRIPTION
## Summary
- Give SplitFlapCounter a fixed width and larger font for prominence
- Resize progress ring and center both counter and ring within stack

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af73056a188332b9fa2ba8c6c0fceb