### PR TITLE
Add dark mode toggle and adjust quick add defaults

### DIFF
--- a/ProteinFlip/HomeView.swift
+++ b/ProteinFlip/HomeView.swift
@@ -8,6 +8,7 @@ struct HomeView: View {
     @State private var showHistory = false
     @State private var showGoals = false
     @State private var lastAddition: Int?
+    @AppStorage("darkModeEnabled") private var darkModeEnabled = false
 
     var body: some View {
         NavigationStack {
@@ -64,6 +65,9 @@ struct HomeView: View {
                         Button { showGoals = true } label: {
                             Label("Goals", systemImage: "target")
                         }
+                        Toggle(isOn: $darkModeEnabled) {
+                            Label("Dark Mode", systemImage: "moon.fill")
+                        }
                     } label: {
                         Image(systemName: "line.3.horizontal")
                     }
@@ -71,6 +75,7 @@ struct HomeView: View {
             }
             .sheet(isPresented: $showHistory) { HistoryView().environmentObject(store) }
             .sheet(isPresented: $showGoals) { GoalsView().environmentObject(store) }
+            .preferredColorScheme(darkModeEnabled ? .dark : nil)
             .onAppear {
                 displayValue = store.todayGrams
                 Haptics.prepare()
@@ -115,7 +120,7 @@ struct HomeView: View {
 
     private var quickAdds: some View {
         HStack(spacing: 8) {
-            ForEach([20, 30, 40], id: \.self) { v in
+            ForEach([20, 40, 50], id: \.self) { v in
                 Button("+\(v) g") { addQuick(v) }
                     .buttonStyle(.bordered)
             }


### PR DESCRIPTION
## Summary
- add a dark mode toggle to the navigation menu and persist the preference
- apply the preferred color scheme so the toggle immediately updates the UI
- change the quick-add protein buttons to 20 g, 40 g, and 50 g defaults

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f513b1ff8c83328b21dd6d4c707e87